### PR TITLE
Hide header on scroll and refine gold button glow

### DIFF
--- a/index-fr.html
+++ b/index-fr.html
@@ -10,31 +10,148 @@
   <link href="https://fonts.googleapis.com/css2?family=Staatliches&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
-      --primary-color: #111;
+      --primary-color: #111111;
       --accent-color: #ffcc00;
+      --accent-highlight: rgba(255, 204, 0, 0.85);
       --dark-bg: #000000;
       --light-text: #f0f0f0;
-      --border-radius: 12px;
+      --glass-bg: rgba(17, 17, 17, 0.78);
+      --border-radius: 18px;
+      --glow: 0 20px 45px rgba(255, 204, 0, 0.25);
+    }
+
+    * {
+      box-sizing: border-box;
     }
 
     body {
       margin: 0;
       font-family: 'Roboto', sans-serif;
-      background: linear-gradient(135deg, #000000, #1a1a1a);
+      background: radial-gradient(circle at 12% 18%, rgba(255, 204, 0, 0.12) 0%, rgba(0, 0, 0, 0.82) 48%),
+        radial-gradient(circle at 82% 6%, rgba(255, 204, 0, 0.1) 0%, rgba(17, 17, 17, 0.92) 58%),
+        linear-gradient(135deg, #000000 0%, #1a1a1a 100%);
       color: var(--light-text);
+      min-height: 100vh;
+      position: relative;
+      overflow-x: hidden;
+    }
+
+    body::before,
+    body::after {
+      content: "";
+      position: fixed;
+      width: 70vmax;
+      height: 70vmax;
+      background: radial-gradient(circle, rgba(255, 204, 0, 0.2), transparent 60%);
+      filter: blur(60px);
+      opacity: 0.6;
+      z-index: -2;
+      animation: float 16s infinite ease-in-out;
+    }
+
+    body::before {
+      top: -20vmax;
+      right: -25vmax;
+    }
+
+    body::after {
+      bottom: -25vmax;
+      left: -20vmax;
+      background: radial-gradient(circle, rgba(255, 204, 0, 0.32), transparent 65%);
+      animation-delay: -6s;
+    }
+
+    @keyframes float {
+      0%,
+      100% {
+        transform: translate3d(0, 0, 0) scale(1);
+      }
+
+      50% {
+        transform: translate3d(2%, -3%, 0) scale(1.05);
+      }
+    }
+
+    @keyframes sweep {
+      0%,
+      55% {
+        transform: translateX(-120%);
+      }
+
+      75% {
+        transform: translateX(120%);
+      }
+
+      100% {
+        transform: translateX(120%);
+      }
+    }
+
+    @keyframes pulseGlow {
+      0%,
+      100% {
+        box-shadow: 0 12px 30px rgba(255, 204, 0, 0.45), 0 0 22px rgba(255, 204, 0, 0.18);
+      }
+
+      50% {
+        box-shadow: 0 18px 36px rgba(255, 204, 0, 0.55), 0 0 32px rgba(255, 204, 0, 0.32);
+      }
     }
 
     header {
-      background-color: var(--primary-color);
-      padding: 20px;
+      background: linear-gradient(135deg, rgba(17, 17, 17, 0.9), rgba(34, 34, 34, 0.92));
+      padding: 28px 20px;
       display: flex;
       justify-content: center;
       align-items: center;
+      gap: 24px;
+      position: sticky;
+      top: 0;
+      z-index: 5;
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 10px 35px rgba(0, 0, 0, 0.35);
+      transition: transform 0.4s ease, opacity 0.4s ease;
+    }
+
+    header.header-hidden {
+      transform: translateY(-120%);
+      opacity: 0;
+    }
+
+    .logo-link {
+      display: inline-flex;
+      padding: 10px;
+      border-radius: calc(var(--border-radius) + 6px);
+      background: radial-gradient(circle at top left, rgba(255, 204, 0, 0.35), transparent 60%);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+      transition: transform 0.3s ease;
+    }
+
+    .logo-link:hover {
+      transform: translateY(-4px) scale(1.02);
     }
 
     .logo-link img {
-      height: 60px;
+      height: 68px;
       border-radius: var(--border-radius);
+      display: block;
+    }
+
+    .title-block h1 {
+      font-family: 'Staatliches', cursive;
+      letter-spacing: 2px;
+      font-size: clamp(1.8rem, 3vw, 2.8rem);
+      margin: 0 0 6px;
+      color: var(--accent-color);
+      text-shadow: 0 0 18px rgba(255, 204, 0, 0.35);
+    }
+
+    .title-block p {
+      margin: 0;
+      font-size: 0.95rem;
+      color: rgba(240, 240, 240, 0.85);
+      max-width: 420px;
     }
 
     .container {
@@ -43,108 +160,326 @@
       min-height: 100vh;
     }
 
+    .main-content {
+      flex-grow: 1;
+      padding: clamp(20px, 5vw, 60px);
+    }
+
+    .hero-message {
+      max-width: 760px;
+      margin: 0 auto 40px;
+      text-align: center;
+      background: var(--glass-bg);
+      border-radius: calc(var(--border-radius) + 6px);
+      padding: 32px clamp(18px, 4vw, 48px);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 25px 70px rgba(6, 6, 20, 0.45);
+      backdrop-filter: blur(18px);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero-message::before {
+      content: "";
+      position: absolute;
+      inset: -1px;
+      border-radius: inherit;
+      background: linear-gradient(120deg, transparent 0%, rgba(255, 204, 0, 0.35) 55%, transparent 100%);
+      transform: translateX(-120%);
+      animation: sweep 8s ease-in-out infinite;
+      opacity: 0.6;
+      pointer-events: none;
+    }
+
+    .hero-message::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(255, 204, 0, 0.12), rgba(255, 204, 0, 0.02));
+      opacity: 0.9;
+      pointer-events: none;
+    }
+
+    .hero-message h2 {
+      font-family: 'Staatliches', cursive;
+      font-size: clamp(1.9rem, 4vw, 2.6rem);
+      margin-bottom: 12px;
+      color: var(--accent-color);
+    }
+
+    .hero-message p {
+      font-size: 1.05rem;
+      line-height: 1.6;
+      color: rgba(240, 240, 240, 0.9);
+      margin: 0;
+    }
+
     .search-bar {
       display: flex;
       justify-content: center;
-      padding: 30px 20px;
+      margin: 0 auto;
+      padding: 20px;
+      max-width: 600px;
+      background: var(--glass-bg);
+      border-radius: 999px;
+      backdrop-filter: blur(20px);
+      box-shadow: var(--glow);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      position: relative;
+    }
+
+    .search-bar::before {
+      content: "";
+      position: absolute;
+      inset: 2px;
+      border-radius: 999px;
+      background: linear-gradient(135deg, rgba(255, 204, 0, 0.14), rgba(255, 204, 0, 0.05));
+      z-index: -1;
+    }
+
+    .search-bar form {
+      display: flex;
+      width: 100%;
+      gap: 12px;
     }
 
     .search-bar input {
-      padding: 12px;
-      width: 300px;
+      flex: 1;
+      padding: 14px 18px;
       font-size: 1rem;
-      border-radius: var(--border-radius) 0 0 var(--border-radius);
-      border: 1px solid #444;
-      background-color: #222;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      background: rgba(12, 12, 12, 0.75);
       color: var(--light-text);
       outline: none;
+      transition: border 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+    }
+
+    .search-bar input:focus {
+      border-color: rgba(255, 204, 0, 0.6);
+      box-shadow: 0 0 0 4px rgba(255, 204, 0, 0.18);
+      background: rgba(26, 26, 26, 0.9);
     }
 
     .search-bar button {
-      padding: 12px 20px;
+      padding: 14px 26px;
       font-size: 1rem;
-      border: 1px solid #444;
-      border-left: none;
-      border-radius: 0 var(--border-radius) var(--border-radius) 0;
-      background-color: var(--accent-color);
-      color: #000;
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, var(--accent-color), var(--accent-highlight));
+      color: #050505;
       cursor: pointer;
-      transition: background-color 0.3s;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+      box-shadow: 0 12px 30px rgba(255, 204, 0, 0.45);
+      animation: pulseGlow 4.5s ease-in-out infinite;
+      transition: transform 0.25s ease, box-shadow 0.25s ease;
     }
 
     .search-bar button:hover {
-      background-color: #e6b800;
+      transform: translateY(-2px) scale(1.02);
+      box-shadow: 0 18px 40px rgba(255, 204, 0, 0.3);
+    }
+
+    .search-bar button:active {
+      transform: translateY(1px) scale(0.98);
     }
 
     .links {
-      text-align: center;
-      padding: 20px;
+      display: grid;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      margin: 45px auto 50px;
+      max-width: 920px;
     }
 
     .interactive-link {
-      margin: 10px;
-      padding: 12px 20px;
-      background-color: #111;
-      border-radius: var(--border-radius);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      padding: 18px 20px;
       text-decoration: none;
+      border-radius: var(--border-radius);
+      background: linear-gradient(145deg, rgba(10, 10, 10, 0.92), rgba(26, 26, 26, 0.7));
+      border: 1px solid rgba(255, 255, 255, 0.08);
       color: var(--accent-color);
-      font-weight: bold;
-      box-shadow: 0 2px 5px rgba(255, 255, 255, 0.05);
-      transition: transform 0.2s, background-color 0.3s;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      transition: transform 0.3s ease, box-shadow 0.3s ease, border 0.3s ease;
+      position: relative;
+      overflow: visible;
+      z-index: 0;
+      box-shadow: 0 12px 28px rgba(255, 204, 0, 0.18);
+    }
+
+    .interactive-link::before {
+      content: "";
+      position: absolute;
+      inset: -22px;
+      border-radius: inherit;
+      background: radial-gradient(circle at center, rgba(255, 204, 0, 0.28), transparent 70%);
+      opacity: 0;
+      transform: scale(0.85);
+      transition: opacity 0.35s ease, transform 0.35s ease;
+      pointer-events: none;
+      z-index: -1;
+    }
+
+    .interactive-link::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: linear-gradient(135deg, rgba(255, 204, 0, 0.16), rgba(255, 204, 0, 0.02));
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      z-index: -1;
     }
 
     .interactive-link:hover {
-      background-color: #222;
-      transform: translateY(-3px);
+      transform: translateY(-6px) scale(1.02);
+      box-shadow: 0 22px 40px rgba(0, 0, 0, 0.48), 0 0 42px rgba(255, 204, 0, 0.32);
+      border-color: rgba(255, 204, 0, 0.35);
     }
 
-    .main-content {
-      flex-grow: 1;
-      padding: 20px;
+    .interactive-link:hover::before {
+      opacity: 1;
+      transform: scale(1.05);
+    }
+
+    .interactive-link:hover::after {
+      opacity: 1;
     }
 
     .feature-box {
-      background-color: #111;
-      border-radius: var(--border-radius);
-      padding: 20px;
-      margin: 20px auto;
-      max-width: 1000px;
-      box-shadow: 0 4px 12px rgba(255, 255, 255, 0.05);
+      background: var(--glass-bg);
+      border-radius: calc(var(--border-radius) + 6px);
+      padding: clamp(24px, 5vw, 36px);
+      margin: 0 auto 60px;
+      max-width: 1050px;
+      box-shadow: 0 30px 80px rgba(8, 8, 20, 0.6);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      backdrop-filter: blur(16px);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .feature-box::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(255, 204, 0, 0.08), transparent 60%);
+      pointer-events: none;
     }
 
     .feature-box h2 {
       font-family: 'Staatliches', cursive;
-      font-size: 2rem;
-      margin-bottom: 10px;
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      margin-bottom: 14px;
       color: var(--accent-color);
+      text-shadow: 0 0 22px rgba(255, 204, 0, 0.3);
+    }
+
+    .feature-box p {
+      margin: 0 0 26px;
+      color: rgba(240, 240, 240, 0.85);
+      font-size: 1.05rem;
+      line-height: 1.7;
     }
 
     .iframe-container {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 20px;
-      justify-content: space-between;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 22px;
     }
 
     .iframe-container iframe {
-      flex: 1 1 45%;
-      min-width: 300px;
-      height: 300px;
+      width: 100%;
+      min-height: 300px;
       border: none;
-      border-radius: var(--border-radius);
-      box-shadow: 0 2px 10px rgba(255, 255, 255, 0.05);
+      border-radius: calc(var(--border-radius) + 4px);
+      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+      background: rgba(8, 8, 8, 0.8);
     }
 
     footer {
-      background-color: var(--primary-color);
-      color: white;
-      padding: 20px;
+      background: linear-gradient(135deg, rgba(10, 10, 10, 0.95), rgba(30, 30, 30, 0.9));
+      color: rgba(245, 245, 245, 0.92);
+      padding: 32px 20px 40px;
       text-align: center;
-      border-top: 4px solid var(--accent-color);
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      backdrop-filter: blur(12px);
+      box-shadow: 0 -10px 40px rgba(0, 0, 0, 0.55);
     }
 
     footer p {
-      margin: 8px 0;
+      margin: 10px auto;
+      max-width: 880px;
+      line-height: 1.6;
+      color: rgba(235, 235, 235, 0.85);
+    }
+
+    footer strong {
+      color: var(--accent-color);
+    }
+
+    @media (max-width: 768px) {
+      header {
+        flex-direction: column;
+        text-align: center;
+      }
+
+      .title-block p {
+        max-width: none;
+      }
+
+      .search-bar {
+        padding: 16px;
+      }
+
+      .search-bar form {
+        flex-direction: column;
+      }
+
+      .search-bar button {
+        width: 100%;
+      }
+
+      .links {
+        margin-top: 35px;
+      }
+    }
+
+    @media (max-width: 520px) {
+      .interactive-link {
+        text-transform: none;
+        letter-spacing: 0.02em;
+      }
+
+      .iframe-container {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *,
+      *::before,
+      *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+
+      .search-bar button {
+        animation: none !important;
+      }
+
+      header {
+        transition: none !important;
+      }
     }
   </style>
 </head>
@@ -154,8 +489,16 @@
       <a href="#" class="logo-link">
         <img src="images/CFH.png" alt="Logo de CFH">
       </a>
+      <div class="title-block">
+        <h1>Chemins de fer hoggynésiens</h1>
+        <p>Une vitrine élégante pour les connexions ferroviaires en direct aux Pays-Bas, en Belgique et au-delà.</p>
+      </div>
     </header>
     <main class="main-content">
+      <section class="hero-message">
+        <h2>Explorez une information voyage au style affirmé</h2>
+        <p>Retrouvez l’essentiel des services ferroviaires, une recherche intelligente et des horaires en direct dans une atmosphère haut de gamme.</p>
+      </section>
       <div class="search-bar">
         <form action="https://www.google.com/search">
           <input type="text" placeholder="Rechercher..." name="q">
@@ -184,15 +527,16 @@
       </div>
     </main>
     <footer>
-  <p><strong>NS</strong> : Planifiez facilement vos voyages en train aux Pays-Bas via le site Web de NS.</p>
-  <p><strong>NS International</strong> : pour les liaisons ferroviaires internationales des Pays-Bas vers la Belgique, l'Allemagne, la France et au-delà.</p>
-  <p><strong>Positions des trains NL</strong> : Affichez les positions en temps réel des trains aux Pays-Bas. Idéal pour les observateurs de trains et les informations de voyage à jour.</p>
-  <p><strong>SNCB</strong> : utilisez la SNCB pour planifier vos voyages en train en Belgique.</p>
-  <p><strong>Haltelink</strong> : Pour des informations en direct sur les bus, trams et métros en Belgique.</p>
-  <p><strong>GPT</strong> : Discutez avec un assistant IA pour des questions, de l'aide ou un soutien créatif.</p>
-  <p><strong>GitHub</strong> : pour gérer et partager des projets de code et collaborer avec les développeurs.</p>
+      <p><strong>NS</strong> : Planifiez facilement vos voyages en train aux Pays-Bas via le site Web de NS.</p>
+      <p><strong>NS International</strong> : pour les liaisons ferroviaires internationales des Pays-Bas vers la Belgique, l'Allemagne, la France et au-delà.</p>
+      <p><strong>Positions des trains NL</strong> : Affichez les positions en temps réel des trains aux Pays-Bas. Idéal pour les observateurs de trains et les informations de voyage à jour.</p>
+      <p><strong>SNCB</strong> : utilisez la SNCB pour planifier vos voyages en train en Belgique.</p>
+      <p><strong>Haltelink</strong> : Pour des informations en direct sur les bus, trams et métros en Belgique.</p>
+      <p><strong>GPT</strong> : Discutez avec un assistant IA pour des questions, de l'aide ou un soutien créatif.</p>
+      <p><strong>GitHub</strong> : pour gérer et partager des projets de code et collaborer avec les développeurs.</p>
       <p>&copy; 2025 Chemins de fer hoggynésiens. Tous droits réservés.</p>
     </footer>
   </div>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -9,31 +9,148 @@
   <link href="https://fonts.googleapis.com/css2?family=Staatliches&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <style>
     :root {
-      --primary-color: #111;
+      --primary-color: #111111;
       --accent-color: #ffcc00;
+      --accent-highlight: rgba(255, 204, 0, 0.85);
       --dark-bg: #000000;
       --light-text: #f0f0f0;
-      --border-radius: 12px;
+      --glass-bg: rgba(17, 17, 17, 0.78);
+      --border-radius: 18px;
+      --glow: 0 20px 45px rgba(255, 204, 0, 0.25);
+    }
+
+    * {
+      box-sizing: border-box;
     }
 
     body {
       margin: 0;
       font-family: 'Roboto', sans-serif;
-      background: linear-gradient(135deg, #000000, #1a1a1a);
+      background: radial-gradient(circle at 12% 18%, rgba(255, 204, 0, 0.12) 0%, rgba(0, 0, 0, 0.82) 48%),
+        radial-gradient(circle at 82% 6%, rgba(255, 204, 0, 0.1) 0%, rgba(17, 17, 17, 0.92) 58%),
+        linear-gradient(135deg, #000000 0%, #1a1a1a 100%);
       color: var(--light-text);
+      min-height: 100vh;
+      position: relative;
+      overflow-x: hidden;
+    }
+
+    body::before,
+    body::after {
+      content: "";
+      position: fixed;
+      width: 70vmax;
+      height: 70vmax;
+      background: radial-gradient(circle, rgba(255, 204, 0, 0.2), transparent 60%);
+      filter: blur(60px);
+      opacity: 0.6;
+      z-index: -2;
+      animation: float 16s infinite ease-in-out;
+    }
+
+    body::before {
+      top: -20vmax;
+      right: -25vmax;
+    }
+
+    body::after {
+      bottom: -25vmax;
+      left: -20vmax;
+      background: radial-gradient(circle, rgba(255, 204, 0, 0.32), transparent 65%);
+      animation-delay: -6s;
+    }
+
+    @keyframes float {
+      0%,
+      100% {
+        transform: translate3d(0, 0, 0) scale(1);
+      }
+
+      50% {
+        transform: translate3d(2%, -3%, 0) scale(1.05);
+      }
+    }
+
+    @keyframes sweep {
+      0%,
+      55% {
+        transform: translateX(-120%);
+      }
+
+      75% {
+        transform: translateX(120%);
+      }
+
+      100% {
+        transform: translateX(120%);
+      }
+    }
+
+    @keyframes pulseGlow {
+      0%,
+      100% {
+        box-shadow: 0 12px 30px rgba(255, 204, 0, 0.45), 0 0 22px rgba(255, 204, 0, 0.18);
+      }
+
+      50% {
+        box-shadow: 0 18px 36px rgba(255, 204, 0, 0.55), 0 0 32px rgba(255, 204, 0, 0.32);
+      }
     }
 
     header {
-      background-color: var(--primary-color);
-      padding: 20px;
+      background: linear-gradient(135deg, rgba(17, 17, 17, 0.9), rgba(34, 34, 34, 0.92));
+      padding: 28px 20px;
       display: flex;
       justify-content: center;
       align-items: center;
+      gap: 24px;
+      position: sticky;
+      top: 0;
+      z-index: 5;
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 10px 35px rgba(0, 0, 0, 0.35);
+      transition: transform 0.4s ease, opacity 0.4s ease;
+    }
+
+    header.header-hidden {
+      transform: translateY(-120%);
+      opacity: 0;
+    }
+
+    .logo-link {
+      display: inline-flex;
+      padding: 10px;
+      border-radius: calc(var(--border-radius) + 6px);
+      background: radial-gradient(circle at top left, rgba(255, 204, 0, 0.35), transparent 60%);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+      transition: transform 0.3s ease;
+    }
+
+    .logo-link:hover {
+      transform: translateY(-4px) scale(1.02);
     }
 
     .logo-link img {
-      height: 60px;
+      height: 68px;
       border-radius: var(--border-radius);
+      display: block;
+    }
+
+    .title-block h1 {
+      font-family: 'Staatliches', cursive;
+      letter-spacing: 2px;
+      font-size: clamp(1.8rem, 3vw, 2.8rem);
+      margin: 0 0 6px;
+      color: var(--accent-color);
+      text-shadow: 0 0 18px rgba(255, 204, 0, 0.35);
+    }
+
+    .title-block p {
+      margin: 0;
+      font-size: 0.95rem;
+      color: rgba(240, 240, 240, 0.85);
+      max-width: 420px;
     }
 
     .container {
@@ -42,108 +159,326 @@
       min-height: 100vh;
     }
 
+    .main-content {
+      flex-grow: 1;
+      padding: clamp(20px, 5vw, 60px);
+    }
+
+    .hero-message {
+      max-width: 760px;
+      margin: 0 auto 40px;
+      text-align: center;
+      background: var(--glass-bg);
+      border-radius: calc(var(--border-radius) + 6px);
+      padding: 32px clamp(18px, 4vw, 48px);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 25px 70px rgba(6, 6, 20, 0.45);
+      backdrop-filter: blur(18px);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .hero-message::before {
+      content: "";
+      position: absolute;
+      inset: -1px;
+      border-radius: inherit;
+      background: linear-gradient(120deg, transparent 0%, rgba(255, 204, 0, 0.35) 55%, transparent 100%);
+      transform: translateX(-120%);
+      animation: sweep 8s ease-in-out infinite;
+      opacity: 0.6;
+      pointer-events: none;
+    }
+
+    .hero-message::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(255, 204, 0, 0.12), rgba(255, 204, 0, 0.02));
+      opacity: 0.9;
+      pointer-events: none;
+    }
+
+    .hero-message h2 {
+      font-family: 'Staatliches', cursive;
+      font-size: clamp(1.9rem, 4vw, 2.6rem);
+      margin-bottom: 12px;
+      color: var(--accent-color);
+    }
+
+    .hero-message p {
+      font-size: 1.05rem;
+      line-height: 1.6;
+      color: rgba(240, 240, 240, 0.9);
+      margin: 0;
+    }
+
     .search-bar {
       display: flex;
       justify-content: center;
-      padding: 30px 20px;
+      margin: 0 auto;
+      padding: 20px;
+      max-width: 600px;
+      background: var(--glass-bg);
+      border-radius: 999px;
+      backdrop-filter: blur(20px);
+      box-shadow: var(--glow);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      position: relative;
+    }
+
+    .search-bar::before {
+      content: "";
+      position: absolute;
+      inset: 2px;
+      border-radius: 999px;
+      background: linear-gradient(135deg, rgba(255, 204, 0, 0.14), rgba(255, 204, 0, 0.05));
+      z-index: -1;
+    }
+
+    .search-bar form {
+      display: flex;
+      width: 100%;
+      gap: 12px;
     }
 
     .search-bar input {
-      padding: 12px;
-      width: 300px;
+      flex: 1;
+      padding: 14px 18px;
       font-size: 1rem;
-      border-radius: var(--border-radius) 0 0 var(--border-radius);
-      border: 1px solid #444;
-      background-color: #222;
+      border-radius: 999px;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      background: rgba(12, 12, 12, 0.75);
       color: var(--light-text);
       outline: none;
+      transition: border 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+    }
+
+    .search-bar input:focus {
+      border-color: rgba(255, 204, 0, 0.6);
+      box-shadow: 0 0 0 4px rgba(255, 204, 0, 0.18);
+      background: rgba(26, 26, 26, 0.9);
     }
 
     .search-bar button {
-      padding: 12px 20px;
+      padding: 14px 26px;
       font-size: 1rem;
-      border: 1px solid #444;
-      border-left: none;
-      border-radius: 0 var(--border-radius) var(--border-radius) 0;
-      background-color: var(--accent-color);
-      color: #000;
+      border-radius: 999px;
+      border: none;
+      background: linear-gradient(135deg, var(--accent-color), var(--accent-highlight));
+      color: #050505;
       cursor: pointer;
-      transition: background-color 0.3s;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+      box-shadow: 0 12px 30px rgba(255, 204, 0, 0.45);
+      animation: pulseGlow 4.5s ease-in-out infinite;
+      transition: transform 0.25s ease, box-shadow 0.25s ease;
     }
 
     .search-bar button:hover {
-      background-color: #e6b800;
+      transform: translateY(-2px) scale(1.02);
+      box-shadow: 0 18px 40px rgba(255, 204, 0, 0.3);
+    }
+
+    .search-bar button:active {
+      transform: translateY(1px) scale(0.98);
     }
 
     .links {
-      text-align: center;
-      padding: 20px;
+      display: grid;
+      gap: 18px;
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+      margin: 45px auto 50px;
+      max-width: 920px;
     }
 
     .interactive-link {
-      margin: 10px;
-      padding: 12px 20px;
-      background-color: #111;
-      border-radius: var(--border-radius);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      padding: 18px 20px;
       text-decoration: none;
+      border-radius: var(--border-radius);
+      background: linear-gradient(145deg, rgba(10, 10, 10, 0.92), rgba(26, 26, 26, 0.7));
+      border: 1px solid rgba(255, 255, 255, 0.08);
       color: var(--accent-color);
-      font-weight: bold;
-      box-shadow: 0 2px 5px rgba(255, 255, 255, 0.05);
-      transition: transform 0.2s, background-color 0.3s;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      transition: transform 0.3s ease, box-shadow 0.3s ease, border 0.3s ease;
+      position: relative;
+      overflow: visible;
+      z-index: 0;
+      box-shadow: 0 12px 28px rgba(255, 204, 0, 0.18);
+    }
+
+    .interactive-link::before {
+      content: "";
+      position: absolute;
+      inset: -22px;
+      border-radius: inherit;
+      background: radial-gradient(circle at center, rgba(255, 204, 0, 0.28), transparent 70%);
+      opacity: 0;
+      transform: scale(0.85);
+      transition: opacity 0.35s ease, transform 0.35s ease;
+      pointer-events: none;
+      z-index: -1;
+    }
+
+    .interactive-link::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: linear-gradient(135deg, rgba(255, 204, 0, 0.16), rgba(255, 204, 0, 0.02));
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      z-index: -1;
     }
 
     .interactive-link:hover {
-      background-color: #222;
-      transform: translateY(-3px);
+      transform: translateY(-6px) scale(1.02);
+      box-shadow: 0 22px 40px rgba(0, 0, 0, 0.48), 0 0 42px rgba(255, 204, 0, 0.32);
+      border-color: rgba(255, 204, 0, 0.35);
     }
 
-    .main-content {
-      flex-grow: 1;
-      padding: 20px;
+    .interactive-link:hover::before {
+      opacity: 1;
+      transform: scale(1.05);
+    }
+
+    .interactive-link:hover::after {
+      opacity: 1;
     }
 
     .feature-box {
-      background-color: #111;
-      border-radius: var(--border-radius);
-      padding: 20px;
-      margin: 20px auto;
-      max-width: 1000px;
-      box-shadow: 0 4px 12px rgba(255, 255, 255, 0.05);
+      background: var(--glass-bg);
+      border-radius: calc(var(--border-radius) + 6px);
+      padding: clamp(24px, 5vw, 36px);
+      margin: 0 auto 60px;
+      max-width: 1050px;
+      box-shadow: 0 30px 80px rgba(8, 8, 20, 0.6);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      backdrop-filter: blur(16px);
+      position: relative;
+      overflow: hidden;
+    }
+
+    .feature-box::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(255, 204, 0, 0.08), transparent 60%);
+      pointer-events: none;
     }
 
     .feature-box h2 {
       font-family: 'Staatliches', cursive;
-      font-size: 2rem;
-      margin-bottom: 10px;
+      font-size: clamp(2rem, 4vw, 2.8rem);
+      margin-bottom: 14px;
       color: var(--accent-color);
+      text-shadow: 0 0 22px rgba(255, 204, 0, 0.3);
+    }
+
+    .feature-box p {
+      margin: 0 0 26px;
+      color: rgba(240, 240, 240, 0.85);
+      font-size: 1.05rem;
+      line-height: 1.7;
     }
 
     .iframe-container {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 20px;
-      justify-content: space-between;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 22px;
     }
 
     .iframe-container iframe {
-      flex: 1 1 45%;
-      min-width: 300px;
-      height: 300px;
+      width: 100%;
+      min-height: 300px;
       border: none;
-      border-radius: var(--border-radius);
-      box-shadow: 0 2px 10px rgba(255, 255, 255, 0.05);
+      border-radius: calc(var(--border-radius) + 4px);
+      box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+      background: rgba(8, 8, 8, 0.8);
     }
 
     footer {
-      background-color: var(--primary-color);
-      color: white;
-      padding: 20px;
+      background: linear-gradient(135deg, rgba(10, 10, 10, 0.95), rgba(30, 30, 30, 0.9));
+      color: rgba(245, 245, 245, 0.92);
+      padding: 32px 20px 40px;
       text-align: center;
-      border-top: 4px solid var(--accent-color);
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      backdrop-filter: blur(12px);
+      box-shadow: 0 -10px 40px rgba(0, 0, 0, 0.55);
     }
 
     footer p {
-      margin: 8px 0;
+      margin: 10px auto;
+      max-width: 880px;
+      line-height: 1.6;
+      color: rgba(235, 235, 235, 0.85);
+    }
+
+    footer strong {
+      color: var(--accent-color);
+    }
+
+    @media (max-width: 768px) {
+      header {
+        flex-direction: column;
+        text-align: center;
+      }
+
+      .title-block p {
+        max-width: none;
+      }
+
+      .search-bar {
+        padding: 16px;
+      }
+
+      .search-bar form {
+        flex-direction: column;
+      }
+
+      .search-bar button {
+        width: 100%;
+      }
+
+      .links {
+        margin-top: 35px;
+      }
+    }
+
+    @media (max-width: 520px) {
+      .interactive-link {
+        text-transform: none;
+        letter-spacing: 0.02em;
+      }
+
+      .iframe-container {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      *,
+      *::before,
+      *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+      }
+
+      .search-bar button {
+        animation: none !important;
+      }
+
+      header {
+        transition: none !important;
+      }
     }
   </style>
 </head>
@@ -153,8 +488,16 @@
       <a href="#" class="logo-link">
         <img src="images/HS.jpg" alt="Logo van HS">
       </a>
+      <div class="title-block">
+        <h1>Hoggynesische Spoorwegen</h1>
+        <p>Een elegante hub voor realtime treinverbindingen in Nederland, België en daarbuiten.</p>
+      </div>
     </header>
     <main class="main-content">
+      <section class="hero-message">
+        <h2>Ontdek stijlvolle reisinformatie op één plek</h2>
+        <p>Blijf geïnspireerd met een premium overzicht van spoorwegdiensten, slimme zoekmogelijkheden en live vertrekstaten.</p>
+      </section>
       <div class="search-bar">
         <form action="https://www.google.com/search">
           <input type="text" placeholder="Zoeken..." name="q">
@@ -183,17 +526,18 @@
         </div>
       </div>
     </main>
-   <footer>
-  <p><strong>NS</strong>: Plan je treinreizen binnen Nederland eenvoudig via de NS-website.</p>
-  <p><strong>NS International</strong>: Voor internationale treinverbindingen vanuit Nederland naar België, Duitsland, Frankrijk en verder.</p>
-  <p><strong>Treinposities NL</strong>: Bekijk realtime posities van treinen in Nederland. Ideaal voor treinspotters en actuele reisinformatie.</p>
-  <p><strong>NMBS</strong>: Gebruik NMBS om treinreizen binnen België te plannen.</p>
-  <p><strong>Haltelink</strong>: Voor live informatie over bussen, trams en metro's binnen België.</p>
-  <p><strong>GPT</strong>: Chat met een AI-assistent voor vragen, hulp of creatieve ondersteuning.</p>
-  <p><strong>GitHub</strong>: Voor het beheren en delen van codeprojecten en samenwerking met ontwikkelaars.</p>
-  <p>&copy; 2025 Hoggynesische Spoorwegen. Alle rechten voorbehouden.</p>
-</footer>
+    <footer>
+      <p><strong>NS</strong>: Plan je treinreizen binnen Nederland eenvoudig via de NS-website.</p>
+      <p><strong>NS International</strong>: Voor internationale treinverbindingen vanuit Nederland naar België, Duitsland, Frankrijk en verder.</p>
+      <p><strong>Treinposities NL</strong>: Bekijk realtime posities van treinen in Nederland. Ideaal voor treinspotters en actuele reisinformatie.</p>
+      <p><strong>NMBS</strong>: Gebruik NMBS om treinreizen binnen België te plannen.</p>
+      <p><strong>Haltelink</strong>: Voor live informatie over bussen, trams en metro's binnen België.</p>
+      <p><strong>GPT</strong>: Chat met een AI-assistent voor vragen, hulp of creatieve ondersteuning.</p>
+      <p><strong>GitHub</strong>: Voor het beheren en delen van codeprojecten en samenwerking met ontwikkelaars.</p>
+      <p>&copy; 2025 Hoggynesische Spoorwegen. Alle rechten voorbehouden.</p>
+    </footer>
 
   </div>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,38 @@
+(function () {
+  function initHeaderWatcher() {
+    const header = document.querySelector('header');
+    if (!header) {
+      return;
+    }
+
+    let lastScrollY = window.scrollY;
+    let ticking = false;
+    const revealThreshold = header.offsetHeight;
+
+    const update = () => {
+      const currentScroll = window.scrollY;
+
+      if (currentScroll > lastScrollY && currentScroll > revealThreshold) {
+        header.classList.add('header-hidden');
+      } else if (currentScroll < lastScrollY - 4 || currentScroll <= revealThreshold) {
+        header.classList.remove('header-hidden');
+      }
+
+      lastScrollY = currentScroll;
+      ticking = false;
+    };
+
+    window.addEventListener('scroll', () => {
+      if (!ticking) {
+        window.requestAnimationFrame(update);
+        ticking = true;
+      }
+    }, { passive: true });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initHeaderWatcher, { once: true });
+  } else {
+    initHeaderWatcher();
+  }
+})();


### PR DESCRIPTION
## Summary
- hide the localized header bar when scrolling down and reveal it on upward scroll using a shared script
- link both landing pages to the new script and disable transitions for reduced-motion users
- refresh the button glow treatments so the gold highlight sits beneath each card

## Testing
- Not run (static content update)

------
https://chatgpt.com/codex/tasks/task_e_690cb882c9948322b288db89c8e12e07